### PR TITLE
if available use mb_strlen() instead of strlen()

### DIFF
--- a/test/rules/DoesntExceedMaxLineLength.php
+++ b/test/rules/DoesntExceedMaxLineLength.php
@@ -11,13 +11,18 @@ namespace li3_quality\test\rules;
 class DoesntExceedMaxLineLength extends \li3_quality\test\Rule {
 
 	public function apply($testable) {
-		$message = "Maximum line length exceeded";
 		$maxLength = 100;
 		$tabWidth  = 3;
+		$message = "Maximum line length " . $maxLength . " exceeded";
+
+		$strlenFunction = 'strlen';
+		if(function_exists('mb_strlen')) {
+			$strlenFunction = 'mb_strlen';
+		}
 
 		foreach($testable->lines() as $i => $line) {
 			$tabBounty = substr_count($line, "\t") * $tabWidth;
-			if(($length = $tabBounty + strlen($line)) > 100) {
+			if(($length = $tabBounty + $strlenFunction($line)) > $maxLength) {
 				$this->addViolation(array(
 					'message' => $message,
 					'line' => $i+1,


### PR DESCRIPTION
This prevents failed checks for longish lines with multibyte characters (like if you have non Latin characters in comments). Also modified the fail message to include max allowed length.
