### PR TITLE
Better failure reporting, and parser config options

### DIFF
--- a/test/Testable.php
+++ b/test/Testable.php
@@ -72,7 +72,7 @@ class Testable extends \lithium\core\Object {
 	 */
 	public function tokens() {
 		if ($this->_tokens === null) {
-			$this->_tokens = Parser::tokenize($this->source());
+			$this->_tokens = Parser::tokenize($this->source(), $this->_config);
 		}
 		return $this->_tokens;
 	}

--- a/test/Unit.php
+++ b/test/Unit.php
@@ -35,7 +35,10 @@ class Unit extends \lithium\test\Unit  {
 	 * @return bool
 	 */
 	public function assertRulePass($source, $rule, $message = '{:message}') {
-		return $this->assert($this->_mockRule($rule, $source), $message);
+		return $this->assert($this->_mockRule($rule, $source), $message, array(
+			'expected' => 'pass',
+			'result' => $this->rule->violations(),
+		));
 	}
 
 	/**
@@ -47,7 +50,10 @@ class Unit extends \lithium\test\Unit  {
 	 * @return bool
 	 */
 	public function assertRuleFail($source, $rule, $message = '{:message}') {
-		return $this->assert(!$this->_mockRule($rule, $source), $message);
+		return $this->assert(!$this->_mockRule($rule, $source), $message, array(
+			'expected' => 'fail',
+			'result' => $this->rule->violations(),
+		));
 	}
 
 	/**


### PR DESCRIPTION
We have better output and pass config into parser which is necessary to avoid it being wrapped before tokenized. 
