### PR TITLE
Too many spaces causing operator spacing test to fail

### DIFF
--- a/test/rules/HasCorrectInlineHTML.php
+++ b/test/rules/HasCorrectInlineHTML.php
@@ -55,7 +55,7 @@ class HasCorrectInlineHTML extends \li3_quality\test\Rule {
 				foreach ($matches as $match) {
 					if (isset($match[0]) && preg_match($this->matchPattern, $match[0]) === 0) {
 						$this->addViolation(array(
-							'message' =>  $message,
+							'message' => $message,
 							'line' => $lineNumber,
 						));
 					}


### PR DESCRIPTION
The operator space was merged first, yet the short tag fix was made first so it was never code sniffed by operator spacing.
