### PR TITLE
Removing 'no spaces' requirement from HasCorrectInlineHTML

### DIFF
--- a/test/rules/HasCorrectInlineHTML.php
+++ b/test/rules/HasCorrectInlineHTML.php
@@ -19,7 +19,7 @@ class HasCorrectInlineHTML extends \li3_quality\test\Rule {
 	 *
 	 * @var string
 	 */
-	public $matchPattern = '/^\<\?=[^;\s]+\; \?\>$/';
+	public $matchPattern = '/^\<\?=[^;]+\; \?\>$/';
 
 	/**
 	 * The pattern to match all short tags


### PR DESCRIPTION
There are several cases where the auto-escaping inline html syntax can include a space, especially when using the form helper.  See, http://lithify.me/docs/manual/handling-http-requests/views.wiki.

I made the smallest possible change to the regex in the rule to allow the form helper syntax.

-Matt
