### PR TITLE
Allow operator operators to span over multiple lines.

### DIFF
--- a/test/rules/OperatorSpacing.php
+++ b/test/rules/OperatorSpacing.php
@@ -102,6 +102,16 @@ class OperatorSpacing extends \li3_quality\test\Rule {
 			'tokens' => array(
 				T_DOUBLE_COLON,
 				T_PAAMAYIM_NEKUDOTAYIM,
+			),
+		),
+		'objectOperator' => array(
+			'relativeTokens' => array(
+				'before' => 1,
+				'length' => 3,
+			),
+			'regex' => '/([^ ]|^){:content}[^ ]/',
+			'message' => 'Operator `->` must not be be surrounded by 1 space or on its own line.',
+			'tokens' => array(
 				T_OBJECT_OPERATOR,
 			),
 		),

--- a/tests/cases/test/rules/OperatorSpacingTest.php
+++ b/tests/cases/test/rules/OperatorSpacingTest.php
@@ -323,6 +323,17 @@ EOD;
 		$code = '$foo = -$bar;';
 		$this->assertRulePass($code, $this->rule);
 	}
+
+	public function testOperatorSpacingWithChaining() {
+		$code = <<<EOD
+\$this->assertTrue(\$chain->called('method1')
+	->called('method2')->with('bar')
+	->called('method1')
+	->success());
+EOD;
+		$this->assertRulePass($code, $this->rule);
+	}
+
 }
 
 ?>


### PR DESCRIPTION
If accepted, then dev should be merged into master (which I can do) to prevent false negatives on lithium core.
