### PR TITLE
Added two tests that fail when defining short arrays (see #51)

### DIFF
--- a/tests/cases/test/rules/HasCorrectTabIndentionTest.php
+++ b/tests/cases/test/rules/HasCorrectTabIndentionTest.php
@@ -44,6 +44,28 @@ EOD;
 		$this->assertRuleFail($code, $this->rule);
 	}
 
+	public function testCorrectShortArrayTabbing() {
+		$code = <<<EOD
+\$foo = [
+	'bar',
+	'baz',
+	'foobar',
+];
+EOD;
+		$this->assertRulePass($code, $this->rule);
+	}
+
+	public function testIncorrectShortArrayTabbing() {
+		$code = <<<EOD
+\$foo = [
+'bar',
+		'baz',
+	'foobar',
+];
+EOD;
+		$this->assertRuleFail($code, $this->rule);
+	}
+
 	public function testCorrectFunctionTabbing() {
 		$code = <<<EOD
 function foo() {


### PR DESCRIPTION
Related to [#51](https://github.com/UnionOfRAD/li3_quality/issues/51)
