### PR TITLE
Stop propagating wrong tab indentation.

### DIFF
--- a/test/rules/HasCorrectTabIndention.php
+++ b/test/rules/HasCorrectTabIndention.php
@@ -36,7 +36,7 @@ class HasCorrectTabIndention extends \li3_quality\test\Rule {
 
 	/**
 	 * Where the current tab count is held. This is a very relative process and a close count
-	 * shoudl be kept.
+	 * should be kept.
 	 *
 	 * @var integer
 	 */
@@ -65,6 +65,7 @@ class HasCorrectTabIndention extends \li3_quality\test\Rule {
 						)),
 						'line' => $lineIndex + 1,
 					));
+					$this->_currentCount = $actual;
 				}
 			}
 		}

--- a/tests/cases/test/rules/HasCorrectTabIndentionTest.php
+++ b/tests/cases/test/rules/HasCorrectTabIndentionTest.php
@@ -481,6 +481,18 @@ EOD;
 		$this->assertRulePass($code, $this->rule);
 	}
 
+	public function testFailingTabIndentPropagation() {
+		$code = <<<EOD
+\$array = array(
+	'level1' => array(
+		'level2' => array(
+			'level3' => array(
+))));
+echo 'foo';
+EOD;
+		$this->assertRuleFail($code, $this->rule);
+		$this->assertCount(1, $this->rule->violations());
+	}
 }
 
 ?>


### PR DESCRIPTION
Once an incorrect tab was detected, sometimes it still propagated all over the rest of the code and made it pretty difficult to identify the origin of "chaos".

@BlaineSch, I used a camel case name for this PR because I'm pretty sure youLoveCamelCase ;-)
