### PR TITLE
Class name suffixed by `'Exception'` no more fail when methods/variables are not protected by an underscore.

### DIFF
--- a/tests/cases/test/rules/ProtectedNamesStartWithUnderscoreTest.php
+++ b/tests/cases/test/rules/ProtectedNamesStartWithUnderscoreTest.php
@@ -42,6 +42,17 @@ EOD;
 		$this->assertRulePass($code, $this->rule);
 	}
 
+	public function testUnderscoreIsNotRequiredForException() {
+		$code = <<<EOD
+class FooBarException extend Exception {
+	protected string \$message ;
+	protected int \$code ;
+	protected string \$file ;
+	protected int \$line ;
+}
+EOD;
+		$this->assertRuleWarning($code, $this->rule);
+	}
 }
 
 ?>


### PR DESCRIPTION
The simpler here is imo to introduce a new convention for the exception class to make it comptatible to the PHP API. So if a class name is suffixed by `'Exception'`, we consider it's an exception and it'll only show a couple of warnings instead of errors.
