### PR TITLE
Add command line option for excluding testables

### DIFF
--- a/tests/cases/extensions/command/QualityTest.php
+++ b/tests/cases/extensions/command/QualityTest.php
@@ -4,61 +4,60 @@ namespace li3_quality\tests\cases\extensions\command;
 
 use li3_quality\extensions\command\Quality;
 use li3_quality\tests\mocks\extensions\command\MockQuality;
-use li3_quality\test\Rules;
 use lithium\console\Request;
+use li3_quality\analysis\ParserException;
 
 class QualityTest extends \li3_quality\test\Unit {
+	protected $_backup = array();
 
-	/**
-	 * $this->_backup['cwd'] = getcwd();
-	 * $this->_backup['_SERVER'] = $_SERVER;
-	 * $_SERVER['argv'] = array();
-	 * chdir(LITHIUM_LIBRARY_PATH . '/lithium');
-	 */
+	protected $_classes = array(
+		'response' => 'lithium\tests\mocks\console\MockResponse',
+		'libraries' => 'li3_quality\tests\mocks\core\MockLibraries',
+		'dispatcher' => 'li3_quality\tests\mocks\test\MockDispatcher',
+		'group' => 'li3_quality\tests\mocks\test\MockGroup',
+		'rules' => 'li3_quality\tests\mocks\test\MockRules',
+		'testable' => 'li3_quality\tests\mocks\test\MockTestable'
+	);
+
 	public function setUp() {
-		$this->classes = array(
-			'response' => 'lithium\tests\mocks\console\MockResponseRRR'
-		);
-
-		$this->request = new Request(array('input' => fopen('php://temp', 'w+')));
+		$this->_backup['cwd'] = getcwd();
+		$this->_backup['_SERVER'] = $_SERVER;
+		$_SERVER['argv'] = array();
 	}
 
-	/**
-	 * $_SERVER = $this->_backup['_SERVER'];
-	 * chdir($this->_backup['cwd']);
-	 */
 	public function tearDown() {
+		$reset = array('libraries', 'dispatcher', 'group', 'rules');
+		foreach ($reset as $type) {
+			$class = $this->_classes[$type];
+			$class::reset();
+		}
+		$_SERVER = $this->_backup['_SERVER'];
+		chdir($this->_backup['cwd']);
 	}
 
 	public function checkDefaultInput() {
-		return;
-		$quality = new Quality(array(
-			'request' => $this->request, 'classes' => $this->classes
-		));
+		$quality = $this->_quality();
 		$this->assertIdentical(true, $quality->library);
 		$this->assertIdentical(100, $quality->threshold);
+		$expected = 'resources|webroot|vendor|libraries';
+		$this->assertIdentical($expected, $quality->exclude);
 	}
 
 	public function testOverwriteDefaults() {
-		return;
-		$this->request->params = array(
-			'library' => 'build_test',
-			'threshold' => 80,
+		$params = array(
+			'library' => 'library', 'threshold' => 80, 'exclude' => 'exclude'
 		);
-		$quality = new Quality(array(
-			'request' => $this->request, 'classes' => $this->classes
-		));
+		$quality = $this->_quality(compact('params'));
 
-		$this->assertIdentical('build_tesst', $quality->library);
+		$this->assertIdentical('library', $quality->library);
 		$this->assertIdentical(80, $quality->threshold);
+		$this->assertIdentical('exclude', $quality->exclude);
 	}
 
-	public function testTest() {
-		return;
-		$quality = new Quality(array(
-			'request' => $this->request, 'classes' => $this->classes
-		));
-
+	public function testHelp() {
+		$request = $this->_request();
+		$classes = $this->_classes;
+		$quality = new Quality(compact('request', 'classes'));
 		$quality->run();
 		$result = $quality->response->output;
 
@@ -67,24 +66,392 @@ class QualityTest extends \li3_quality\test\Unit {
 		$this->assertPattern("/li3 quality coverage/", $result);
 	}
 
-	public function testRuleCountInOutput() {
-		return;
-		$mockRule = new Rules;
-		$this->classes['rules'] = $mockRule;
-		print_r($this->classes);
-		$mockQuality = new MockQuality(array(
-			'request' => $this->request, 'classes' => $this->classes
-		));
-		$mockQuality->_testables = function($options, $parent) {
-			echo 'meow';
-			exit;
-			return array();
-		};
+	public function testSyntax() {
+		$quality = $this->_quality();
+		$result = $quality->syntax();
+		$this->assertEqual(true, $result);
 
-		$mockQuality->syntax(null);
-		$result = $mockQuality->response->output;
+		$result = $quality->response->output;
+		$rules = $this->_classes['rules'];
+
+		$ruleCount = count($rules::get());
+		$expected = "/Performing {$ruleCount} rules on 1 classes\./";
+		$this->assertPattern($expected, $result);
 	}
 
+	public function testSyntaxSetsOptionsWhenGit() {
+		$env = array('GIT_DIR' => "git-dir");
+		$quality = $this->_quality(compact('env'));
+		$quality->syntax();
+
+		$this->assertIdentical(true, $quality->plain);
+		$this->assertIdentical(true, $quality->silent);
+	}
+
+	public function testSyntaxOutputOK() {
+		$quality = $this->_quality();
+		$result = $quality->syntax();
+		$this->assertEqual(true, $result);
+		$output = $quality->outputWithStyle;
+
+		$this->assertEqual(5, count($output));
+		list($msg, $style) = $output[4];
+		$expected = "[OK] testables";
+		$this->assertIdentical($expected, $msg);
+		$this->assertIdentical("green", $style);
+	}
+
+	public function testSyntaxOutputFail() {
+		$quality = $this->_quality();
+		$rules = $this->_classes['rules'];
+		$rules::$applyResponse = array(
+			'success' => false, 'warnings' => array(),
+			'violations' => array(array(
+				'line' => "line",
+				'position' => "position",
+				'message' => "violation",
+			))
+		);
+		$result = $quality->syntax();
+		$this->assertEqual(false, $result);
+		$error = $quality->errorWithStyle;
+
+		$this->assertEqual(5, count($error));
+		list($msg, $style) = $error[0];
+		$expected = "[FAIL] testables";
+		$this->assertIdentical($expected, $msg);
+		$this->assertIdentical("red", $style);
+
+		list($msg, $style) = $error[4];
+		$expected = '/line\s+position\s+violation/';
+		$this->assertPattern($expected, $msg);
+		$this->assertIdentical("red", $style['style']);
+	}
+
+	public function testSyntaxOutputWarning() {
+		$quality = $this->_quality();
+		$rules = $this->_classes['rules'];
+		$rules::$applyResponse = array(
+			'success' => true,
+			'warnings' => array(array(
+				'line' => "line",
+				'position' => "position",
+				'message' => "violation",
+			))
+		);
+		$result = $quality->syntax();
+		$this->assertEqual(true, $result);
+		$output = $quality->outputWithStyle;
+
+		$this->assertEqual(9, count($output));
+		list($msg, $style) = $output[8];
+		$expected = '/line\s+position\s+violation/';
+		$this->assertPattern($expected, $msg);
+		$this->assertIdentical("yellow", $style['style']);
+	}
+
+	public function testSyntaxOutputParseError() {
+		$quality = $this->_quality();
+		$rules = $this->_classes['rules'];
+		$rules::$applyResponse = function() {
+			throw new ParserException("foobar");
+		};
+		$result = $quality->syntax();
+		$this->assertEqual(false, $result);
+		$error = $quality->errorWithStyle;
+
+		$this->assertEqual(2, count($error));
+		list($msg, $style) = $error[0];
+		$expected = "[FAIL] testables";
+		$this->assertIdentical($expected, $msg);
+		$this->assertIdentical("red", $style);
+
+		list($msg, $style) = $error[1];
+		$this->assertIdentical("Parse error: foobar", $msg);
+		$this->assertIdentical("red", $style);
+	}
+
+	public function testSyntaxOutputParseErrorVerbose() {
+		$quality = $this->_quality();
+		$quality->verbose = true;
+		$rules = $this->_classes['rules'];
+		$rules::$applyResponse = function() {
+			$exp = new ParserException("foobar");
+			$exp->parserData = array('foo' => "bar");
+			throw $exp;
+		};
+		$quality->syntax();
+		$error = $quality->errorWithStyle;
+
+		$this->assertEqual(3, count($error));
+		list($msg, $style) = $error[2];
+		$expected = print_r(array('foo' => "bar"), true);
+		$this->assertIdentical($expected, $msg);
+		$this->assertIdentical("red", $style);
+	}
+
+	public function testDocumented() {
+		$quality = $this->_quality();
+		$quality->documented();
+
+		$expected = "/Checking documentation on 1 classes\./";
+		$result = $quality->response->output;
+		$this->assertPattern($expected, $result);
+	}
+
+	public function testCoverage() {
+		$quality = $this->_quality();
+		$quality->coverage();
+
+		$expected = "/Checking coverage on 1 classes\./";
+		$result = $quality->response->output;
+		$this->assertPattern($expected, $result);
+	}
+
+	public function testCoverageGreen() {
+		$quality = $this->_quality();
+		$dispatcher = $this->_classes['dispatcher'];
+		$dispatcher::$coverage = array(
+			'testables' => array('percentage' => 86)
+		);
+		$quality->coverage();
+		$output = $quality->outputWithStyle;
+
+		$this->assertEqual(5, count($output));
+		list($msg, $style) = $output[3];
+		$expected = "Checking coverage on 1 classes.";
+		$this->assertIdentical($expected, $msg);
+
+		list($msg, $style) = $output[4];
+		$expected = '/has test\s+\|\s+86\.00%\s+\|\s+testables/';
+		$this->assertPattern($expected, $msg);
+		$this->assertIdentical("green", $style);
+	}
+
+	public function testCoverageRed() {
+		$quality = $this->_quality();
+		$dispatcher = $this->_classes['dispatcher'];
+		$dispatcher::$coverage = array(
+			'testables' => array('percentage' => 0)
+		);
+		$quality->coverage();
+		$output = $quality->outputWithStyle;
+
+		$this->assertEqual(5, count($output));
+		list($msg, $style) = $output[3];
+		$expected = "Checking coverage on 1 classes.";
+		$this->assertIdentical($expected, $msg);
+
+		list($msg, $style) = $output[4];
+		$expected = '/has test\s+\|\s+0\.00%\s+\|\s+testables/';
+		$this->assertPattern($expected, $msg);
+		$this->assertIdentical("red", $style);
+	}
+
+	public function testCoverageYellow() {
+		$quality = $this->_quality();
+		$dispatcher = $this->_classes['dispatcher'];
+		$dispatcher::$coverage = array(
+			'testables' => array('percentage' => 42)
+		);
+		$quality->coverage();
+		$output = $quality->outputWithStyle;
+
+		$this->assertEqual(5, count($output));
+		list($msg, $style) = $output[3];
+		$expected = "Checking coverage on 1 classes.";
+		$this->assertIdentical($expected, $msg);
+
+		list($msg, $style) = $output[4];
+		$expected = '/has test\s+\|\s+42\.00%\s+\|\s+testables/';
+		$this->assertPattern($expected, $msg);
+		$this->assertIdentical("yellow", $style);
+	}
+
+	public function testCoverageNoTest() {
+		$quality = $this->_quality();
+		$group = $this->_classes['group'];
+		$group::$all = array();
+		$quality->coverage();
+		$output = $quality->outputWithStyle;
+
+		$this->assertEqual(5, count($output));
+		list($msg, $style) = $output[3];
+		$expected = "Checking coverage on 1 classes.";
+		$this->assertIdentical($expected, $msg);
+
+		list($msg, $style) = $output[4];
+		$expected = '/no test\s+\|\s+n\/a\s+\|\s+testables/';
+		$this->assertPattern($expected, $msg);
+		$this->assertIdentical("red", $style);
+	}
+
+	public function testTestables() {
+		$quality = $this->_quality();
+		$quality->mockTestables = false;
+		$libraries = $this->_classes['libraries'];
+
+		$result = $quality->invokeMethod('_testables');
+		$expected = array('testables');
+		$this->assertIdentical($expected, $result);
+
+		$this->assertEqual(1, count($libraries::$invocations));
+		$call = $libraries::$invocations[0];
+		list($library, $options) = $call['args'];
+		$this->assertEqual('find', $call['method']);
+		$this->assertEqual($quality->library, $library);
+		$this->assertEqual(true, $options['recursive']);
+		$expected = '/' . $quality->exclude . '/';
+		$this->assertEqual($expected, $options['exclude']);
+	}
+
+	public function testTestablesOptions() {
+		$quality = $this->_quality();
+		$quality->mockTestables = false;
+		$libraries = $this->_classes['libraries'];
+
+		$opts = array('recursive' => false, 'exclude' => 'exclude');
+		$result = $quality->invokeMethod('_testables', array($opts));
+
+		$this->assertEqual(1, count($libraries::$invocations));
+		$call = $libraries::$invocations[0];
+		list($library, $options) = $call['args'];
+		$this->assertEqual('find', $call['method']);
+		$this->assertEqual(false, $options['recursive']);
+		$expected = '/' . $quality->exclude . '|exclude/';
+		$this->assertEqual($expected, $options['exclude']);
+
+		$libraries::reset();
+		$quality->exclude = NULL;
+
+		$opts = array('exclude' => 'exclude');
+		$result = $quality->invokeMethod('_testables', array($opts));
+		$this->assertEqual(1, count($libraries::$invocations));
+		$call = $libraries::$invocations[0];
+		list($library, $options) = $call['args'];
+		$this->assertEqual('/exclude/', $options['exclude']);
+
+		$libraries::reset();
+
+		$result = $quality->invokeMethod('_testables');
+		$this->assertEqual(1, count($libraries::$invocations));
+		$call = $libraries::$invocations[0];
+		list($library, $options) = $call['args'];
+		$this->assertFalse(array_key_exists('exclude', $options));
+	}
+
+	public function testTestablesPathSetsLibrary() {
+		$quality = $this->_quality();
+		$quality->mockTestables = false;
+		$quality->library = "lib1";
+		$quality->pathResponse = "lib2\path-response";
+		$opts = array('path' => "required");
+		$quality->invokeMethod('_testables', array($opts));
+		$libraries = $this->_classes['libraries'];
+		$call = $libraries::$invocations[0];
+		list($library, $options) = $call['args'];
+		$this->assertEqual("lib2", $library);
+		$this->assertEqual("/path-response", $options['path']);
+	}
+
+	public function testTestablesSinglePath() {
+		$quality = $this->_quality();
+		$quality->mockTestables = false;
+		$quality->pathResponse = "path-response";
+		$opts = array('path' => "foo.php");
+		$result = $quality->invokeMethod('_testables', array($opts));
+		$expected = array("path-response");
+		$this->assertIdentical($expected, $result);
+	}
+
+	public function testTestablesNoneFound() {
+		$quality = $this->_quality();
+		$quality->mockTestables = false;
+		$quality->library = "foobar";
+		$libraries = $this->_classes['libraries'];
+		$libraries::$findResponse = array();
+		$quality->invokeMethod('_testables');
+		$this->assertEqual(1, count($quality->stops));
+		$stop = $quality->stops[0];
+		$this->assertEqual(0, $stop[0]);
+		$this->assertEqual("Could not find any files in foobar.", $stop[1]);
+	}
+
+	public function testSyntaxFiltersFromArray() {
+		$quality = $this->_quality();
+		$quality->filters = array('from', 'array');
+		$result = $quality->invokeMethod('_syntaxFilters');
+		$expected = array('from', 'array');
+		$this->assertIdentical($expected, $result);
+	}
+
+	public function testSyntaxFiltersFromString() {
+		$quality = $this->_quality();
+		$quality->filters = 'from, string';
+		$result = $quality->invokeMethod('_syntaxFilters');
+		$expected = array('from', 'string');
+		$this->assertIdentical($expected, $result);
+	}
+
+	public function testSyntaxFiltersFromLibraryFile() {
+		$quality = $this->_quality();
+		$libraries = $this->_classes['libraries'];
+		$rules = $this->_classes['rules'];
+		$path = sys_get_temp_dir();
+		$this->skipIf(!is_writable($path), "Path `{$path}` is not writable.");
+
+		$libraries::add('test_library', compact('path'));
+		$json = array(
+			'rules' => array("from", "file"),
+			'variables' => array("file variables")
+		);
+		mkdir($path . '/test');
+		$tmpfile = $path . '/test/rules.json';
+		file_put_contents($tmpfile, json_encode($json));
+		$quality->library = 'test_library';
+
+		$result = $quality->invokeMethod('_syntaxFilters');
+		$expected = array('from', 'file');
+		$this->assertIdentical($expected, $result);
+
+		$this->assertEqual(1, count($rules::$invocations));
+		$call = $rules::$invocations[0];
+		$this->assertEqual('ruleOptions', $call['method']);
+		$this->assertEqual(array('file variables'), $call['args'][0]);
+
+		unlink($tmpfile);
+		rmdir($path . '/test');
+		$libraries::remove('test_library');
+	}
+
+	public function testSyntaxFiltersFromDefaultFile() {
+		$quality = $this->_quality();
+		$rules = $this->_classes['rules'];
+
+		$result = $quality->invokeMethod('_syntaxFilters');
+		$this->assertTrue(is_array($result));
+
+		$this->assertEqual(1, count($rules::$invocations));
+		$call = $rules::$invocations[0];
+		$this->assertEqual('ruleOptions', $call['method']);
+	}
+
+	protected function _quality(array $options = array()) {
+		$request = $this->_request($options);
+		$classes = $this->_classes;
+		return new MockQuality(compact('request', 'classes'));
+	}
+
+	protected function _request(array $options = array()) {
+		$options += array(
+			'params' => array(), 'input' => fopen('php://temp', 'w+')
+		);
+		$params = $options['params'];
+		unset($options['params']);
+		$request = new Request($options);
+		$request->params += $params;
+		return $request;
+	}
 }
 
 ?>

--- a/tests/mocks/core/MockLibraries.php
+++ b/tests/mocks/core/MockLibraries.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace li3_quality\tests\mocks\core;
+
+/**
+ * A mock of the Libraries class
+ */
+class MockLibraries extends \lithium\core\Libraries {
+	public static $findResponse = array('testables');
+	public static $invocations = array();
+
+	public static function reset() {
+		static::$findResponse = array('testables');
+		static::$invocations = array();
+	}
+
+	public static function find($library, array $options = array()) {
+		$call = array('method' => 'find', 'args' => array($library, $options));
+		static::$invocations[] = $call;
+		return static::$findResponse;
+	}
+}
+
+?>

--- a/tests/mocks/extensions/command/MockQuality.php
+++ b/tests/mocks/extensions/command/MockQuality.php
@@ -3,19 +3,39 @@
 namespace li3_quality\tests\mocks\extensions\command;
 
 class MockQuality extends \li3_quality\extensions\command\Quality {
+	public $outputWithStyle = array();
+	public $errorWithStyle = array();
+	public $mockTestables = array('testables');
+	public $stops = array();
+	public $pathResponse = false;
 
-	public $pathConfig = array();
-
-	protected function _testables($options = array()) {
-		return $this->_filter(__METHOD__, $args, function($self, $args) {
-			$key = (isset($options['path'])) ? $options['path'] : $this->library;
-			if (isset($this->pathConfig[$key])) {
-				return $this->pathConfig[$key];
-			}
-			return parent::_testables($options);
-		});
+	public function out($output = null, $options = array('nl' => 1)) {
+		if ($this->silent) {
+			return;
+		}
+		$this->outputWithStyle[] = array($output, $options);
+		return parent::out($output, $options);
 	}
 
+	public function error($error = null, $options = array('nl' => 1)) {
+		$this->errorWithStyle[] = array($error, $options);
+		return parent::error($error, $options);
+	}
+
+	public function stop($status = 0, $message = null) {
+		$this->stops[] = array($status, $message);
+	}
+
+	protected function _testables($options = array()) {
+		if ($this->mockTestables === false) {
+			return parent::_testables($options);
+		}
+		return $this->mockTestables;
+	}
+
+	protected function _path($path) {
+		return $this->pathResponse;
+	}
 }
 
 ?>

--- a/tests/mocks/test/MockDispatcher.php
+++ b/tests/mocks/test/MockDispatcher.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace li3_quality\tests\mocks\test;
+
+/**
+ * A mock of the Dispather class
+ */
+class MockDispatcher extends \lithium\test\Dispatcher {
+	public static $coverage = NULL;
+
+	public static function reset() {
+		static::$coverage = NULL;
+	}
+
+	public static function run($group = null, array $options = array()) {
+		$report = static::_report($group, $options);
+		$coverage = 'lithium\test\filter\Coverage';
+		$report->results['filters'][$coverage] = static::$coverage;
+		return $report;
+	}
+}
+
+?>

--- a/tests/mocks/test/MockGroup.php
+++ b/tests/mocks/test/MockGroup.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace li3_quality\tests\mocks\test;
+
+/**
+ * A mock of the Group class
+ */
+class MockGroup extends \lithium\test\Group {
+	public static $all = array('testables');
+
+	public static function reset() {
+		static$all = array('testables');
+	}
+
+	public static function all(array $options = array()) {
+		return static::$all;
+	}
+}
+
+?>

--- a/tests/mocks/test/MockRules.php
+++ b/tests/mocks/test/MockRules.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace li3_quality\tests\mocks\test;
+
+/**
+ * A mock of the Rules class
+ */
+class MockRules extends \li3_quality\test\Rules {
+	public static $invocations = array();
+	public static $applyResponse = array(
+		'success' => true, 'warnings' => array()
+	);
+
+	public static function reset() {
+		static::$invocations = array();
+		static::$applyResponse = array(
+			'success' => true, 'warnings' => array()
+		);
+	}
+
+	public static function apply($testable, array $filters = array()) {
+		$resp = static::$applyResponse;
+		return is_callable($resp) ? $resp() : $resp;
+	}
+
+	public static function ruleOptions(array $variables) {
+		$call = array('method' => 'ruleOptions', 'args' => array($variables));
+		static::$invocations[] = $call;
+	}
+}
+
+?>

--- a/tests/mocks/test/MockTestable.php
+++ b/tests/mocks/test/MockTestable.php
@@ -11,10 +11,11 @@ class MockTestable extends \li3_quality\test\Testable {
 	 * Overwrites the default Testable constructor
 	 */
 	public function __construct($config) {
-		$this->_source = $config['source'];
 		$this->_config = $config + array(
+			'source' => '',
 			'wrap' => false,
 		);
+		$this->_source = $this->_config['source'];
 	}
 }
 


### PR DESCRIPTION
Add command line option for excluding testables for quality command(s), also exclude some files by default (resources, webroot, vendor, libraries).

related to #60
