### PR TITLE
Need curly brace syntax support.

### DIFF
--- a/tests/cases/test/rules/HasCorrectTabIndentionTest.php
+++ b/tests/cases/test/rules/HasCorrectTabIndentionTest.php
@@ -481,6 +481,19 @@ EOD;
 		$this->assertRulePass($code, $this->rule);
 	}
 
+	public function testCurlyBraceSyntax() {
+		$code = <<<EOD
+switch (\$case) {
+	case 'case 1':
+		if (static::\${\$var}) {
+			echo 'hello';
+		}
+	break;
+}
+echo 'bar';
+EOD;
+		$this->assertRulePass($code, $this->rule);
+	}
 }
 
 ?>


### PR DESCRIPTION
Looks like the curly brace syntax (i.e. `static::${$var}`) makes li3_quality expecting wrong tab indentation.
I only provide the test case here since it's imo more a lithium issue.
