### PR TITLE
Fixing line ending issue on Windows

### DIFF
--- a/test/rules/TabsOnlyAppearFirst.php
+++ b/test/rules/TabsOnlyAppearFirst.php
@@ -35,7 +35,7 @@ class TabsOnlyAppearFirst extends \li3_quality\test\Rule {
 		$currLine = 1;
 		$allowTabs = true;
 		foreach ($tokens as $token) {
-			$content = $token['content'];
+			$content = str_replace("\r\n", "\n", $token['content']);
 
 			$isNewLine = ($token['line'] > $currLine || (
 				$token['id'] === T_WHITESPACE && preg_match('/\n/', $content)

--- a/tests/cases/test/rules/TabsOnlyAppearFirstTest.php
+++ b/tests/cases/test/rules/TabsOnlyAppearFirstTest.php
@@ -107,6 +107,15 @@ EOD;
 		$this->assertRulePass($code, $this->rule);
 	}
 
+	public function testWindowsStyleLineEndings() {
+		$code = implode(null, array(
+			"\$arr = array(",
+			"\r\n\t'foo' => 'bar',",
+			"\r\n);",
+		));
+
+		$this->assertRulePass($code, $this->rule);
+	}
 }
 
 ?>


### PR DESCRIPTION
Only Unix based platforms were taken into account for the rule
'TabsOnlyAppearFirst'.
