### PR TITLE
Move Rules::init() to bootstrap

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -8,6 +8,7 @@
 
 use lithium\core\Libraries;
 use lithium\g11n\Multibyte;
+use li3_quality\test\Rules;
 
 Libraries::paths(array(
 	'rules' => array(
@@ -19,5 +20,7 @@ Libraries::paths(array(
 if (!Multibyte::config('li3_quality')) {
 	Multibyte::config(array('li3_quality' => array('adapter' => 'Mbstring')));
 }
+
+Rules::init();
 
 ?>

--- a/test/Rules.php
+++ b/test/Rules.php
@@ -131,6 +131,4 @@ class Rules extends \lithium\core\StaticObject {
 	}
 }
 
-Rules::init();
-
 ?>


### PR DESCRIPTION
Slightly smarter - move call to init() from class file to bootstrap
