### PR TITLE
1.1 branch. Change String class to Text in qa/rules/syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
 	"require": {
 		"php": ">=5.3",
         "composer/installers": "1.*",
-        "unionofrad/lithium": "1.0.*@RC"
+        "unionofrad/lithium": "1.1.x-dev"
 	}
 }

--- a/qa/rules/syntax/ConstructsWithoutBrackets.php
+++ b/qa/rules/syntax/ConstructsWithoutBrackets.php
@@ -8,7 +8,7 @@
 
 namespace li3_quality\qa\rules\syntax;
 
-use lithium\util\String;
+use lithium\util\Text;
 
 class ConstructsWithoutBrackets extends \li3_quality\qa\Rule {
 
@@ -72,7 +72,7 @@ class ConstructsWithoutBrackets extends \li3_quality\qa\Rule {
 				}
 				if (preg_match($pattern, $line) === 0) {
 					$this->addViolation(array(
-						'message' => String::insert($message, array(
+						'message' => Text::insert($message, array(
 							'name' => $token['name'],
 						)),
 						'line' => $token['line'],

--- a/qa/rules/syntax/ControlStructuresHaveCorrectSpacing.php
+++ b/qa/rules/syntax/ControlStructuresHaveCorrectSpacing.php
@@ -8,7 +8,7 @@
 
 namespace li3_quality\qa\rules\syntax;
 
-use lithium\util\String;
+use lithium\util\Text;
 
 class ControlStructuresHaveCorrectSpacing extends \li3_quality\qa\Rule {
 
@@ -192,7 +192,7 @@ class ControlStructuresHaveCorrectSpacing extends \li3_quality\qa\Rule {
 	 */
 	protected function _matchPattern($patterns, $body) {
 		foreach ($patterns as $pattern) {
-			if (preg_match(String::insert($pattern, $this->_regexMap), $body) === 1) {
+			if (preg_match(Text::insert($pattern, $this->_regexMap), $body) === 1) {
 				return true;
 			}
 		}

--- a/qa/rules/syntax/HasCorrectDocblockStyle.php
+++ b/qa/rules/syntax/HasCorrectDocblockStyle.php
@@ -8,7 +8,7 @@
 
 namespace li3_quality\qa\rules\syntax;
 
-use lithium\util\String;
+use lithium\util\Text;
 
 class HasCorrectDocblockStyle extends \li3_quality\qa\Rule {
 
@@ -131,7 +131,7 @@ class HasCorrectDocblockStyle extends \li3_quality\qa\Rule {
 		if (is_array($items)) {
 			$items = implode(null, $items);
 		}
-		return String::insert($items, $this->regexInject);
+		return Text::insert($items, $this->regexInject);
 	}
 
 }

--- a/qa/rules/syntax/HasCorrectTabIndention.php
+++ b/qa/rules/syntax/HasCorrectTabIndention.php
@@ -8,7 +8,7 @@
 
 namespace li3_quality\qa\rules\syntax;
 
-use lithium\util\String;
+use lithium\util\Text;
 
 /**
  * Tab indention is a tricky subject. Often the next line is based on the
@@ -52,7 +52,7 @@ class HasCorrectTabIndention extends \li3_quality\qa\Rule {
 				$predicted = $this->_getPredictedIndent($lineIndex, $testable);
 				if ($predicted['tab'] !== null && $actual['tab'] !== $predicted['tab']) {
 					$this->addViolation(array(
-						'message' => String::insert($tabMessage, array(
+						'message' => Text::insert($tabMessage, array(
 							'predicted' => $predicted['tab'],
 							'actual' => $actual['tab'],
 						)),
@@ -61,7 +61,7 @@ class HasCorrectTabIndention extends \li3_quality\qa\Rule {
 				}
 				if ($predicted['minSpace'] !== null && $actual['space'] < $predicted['minSpace']) {
 					$this->addViolation(array(
-						'message' => String::insert($spaceMessage, array(
+						'message' => Text::insert($spaceMessage, array(
 							'predicted' => $predicted['minSpace'],
 							'actual' => $actual['space'],
 						)),

--- a/qa/rules/syntax/HasExplicitPropertyAndMethodVisibility.php
+++ b/qa/rules/syntax/HasExplicitPropertyAndMethodVisibility.php
@@ -8,7 +8,7 @@
 
 namespace li3_quality\qa\rules\syntax;
 
-use lithium\util\String;
+use lithium\util\Text;
 use li3_quality\analysis\Parser;
 
 class HasExplicitPropertyAndMethodVisibility extends \li3_quality\qa\Rule {
@@ -61,7 +61,7 @@ class HasExplicitPropertyAndMethodVisibility extends \li3_quality\qa\Rule {
 					$token = $tokens[$member];
 					$this->addViolation(array(
 						'modifiers' => $modifiers,
-						'message' => String::insert($message, $token),
+						'message' => Text::insert($message, $token),
 						'line' => $token['line'],
 					));
 				}

--- a/qa/rules/syntax/OperatorSpacing.php
+++ b/qa/rules/syntax/OperatorSpacing.php
@@ -8,7 +8,7 @@
 
 namespace li3_quality\qa\rules\syntax;
 
-use lithium\util\String;
+use lithium\util\Text;
 
 class OperatorSpacing extends \li3_quality\qa\Rule {
 
@@ -201,7 +201,7 @@ class OperatorSpacing extends \li3_quality\qa\Rule {
 				$isPHP = $testable->isPHP($token['line']);
 
 				if ($isPHP && empty($token['isString'])) {
-					$pattern = String::insert($inspector['regex'], array(
+					$pattern = Text::insert($inspector['regex'], array(
 						'content' => preg_quote($token['content'], "/"),
 					));
 					$firstId = $id - $inspector['relativeTokens']['before'];
@@ -214,7 +214,7 @@ class OperatorSpacing extends \li3_quality\qa\Rule {
 					}
 					if (preg_match($pattern, $html) === 0) {
 						$this->addViolation(array(
-							'message' => String::insert($inspector['message'], $token),
+							'message' => Text::insert($inspector['message'], $token),
 							'line' => $token['line'],
 						));
 					}

--- a/qa/rules/syntax/ProtectedNamesStartWithUnderscore.php
+++ b/qa/rules/syntax/ProtectedNamesStartWithUnderscore.php
@@ -8,7 +8,7 @@
 
 namespace li3_quality\qa\rules\syntax;
 
-use lithium\util\String;
+use lithium\util\Text;
 use li3_quality\analysis\Parser;
 
 class ProtectedNamesStartWithUnderscore extends \li3_quality\qa\Rule {
@@ -41,7 +41,7 @@ class ProtectedNamesStartWithUnderscore extends \li3_quality\qa\Rule {
 				$classTokenId = $testable->findNext(array(T_STRING), $token['parent']);
 				$classname = $tokens[$classTokenId]['content'];
 				$params = array(
-					'message' => String::insert($message, array(
+					'message' => Text::insert($message, array(
 						'name' => $parentLabel,
 					)),
 					'line' => $token['line']

--- a/qa/rules/syntax/WeakComparisonOperators.php
+++ b/qa/rules/syntax/WeakComparisonOperators.php
@@ -8,7 +8,7 @@
 
 namespace li3_quality\qa\rules\syntax;
 
-use lithium\util\String;
+use lithium\util\Text;
 
 class WeakComparisonOperators extends \li3_quality\qa\Rule {
 
@@ -37,7 +37,7 @@ class WeakComparisonOperators extends \li3_quality\qa\Rule {
 		foreach ($filtered as $id) {
 			$token = $tokens[$id];
 			$this->addWarning(array(
-				'message' => String::insert($message, array(
+				'message' => Text::insert($message, array(
 					'key' => token_name($token['id']),
 					'value' => $this->inspectableTokens[$token['id']],
 				)),


### PR DESCRIPTION
Updating the syntax rules to use the Text class instead of deprecated String class.
