### PR TITLE
Update Travis configuration to only run PHP version 5.5, 5.6, and 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
 
 before_install:
   - cd ../


### PR DESCRIPTION
Travis CI continues to fail as it is trying to run on PHP 5.3 and 5.4 when 5.5 is the minimum requirement.
